### PR TITLE
[misc] bump redis max version to <5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ fast = [
     "aiodns>=3.0.0",
 ]
 redis = [
-    "redis[hiredis]>=5.0.1,<5.1.0",
+    "redis[hiredis]>=5.0.1,<5.3.0",
 ]
 mongo = [
     "motor>=3.3.2,<3.7.0",


### PR DESCRIPTION
# Description

Added support for redis 5.1 and 5.2 versions. Release notes: https://github.com/redis/redis-py/releases

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Running `pytest --redis redis://<host>:<port>/<db> tests` results in `1539 passed, 22 skipped in 11.21s`.

**Test Configuration**:
* Operating System: Fedora 41
* Python version: 3.13.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
